### PR TITLE
raw_to_whole with arbitrary precision

### DIFF
--- a/nanohakase/util.py
+++ b/nanohakase/util.py
@@ -120,5 +120,5 @@ def sign(private_key, hash):
 def whole_to_raw(whole: str):
   return int(Decimal(whole)*(10**NANO_DECIMALS))
 
-def raw_to_whole(raw):
-  return math.floor((raw*100)/(10**NANO_DECIMALS))/100
+def raw_to_whole(raw: int, precision: int = 2):
+  return math.floor((raw*10**precision)/(10**NANO_DECIMALS))/10**precision


### PR DESCRIPTION
Hi, 

Thank you for making this library! I use it quite a lot lately, but one thing that I would really appreciate is converting raw to nano with greater precision than just default two decimal places (I am referring to function `raw_to_whole`), so I opened this pull request. Let me know if you have any suggestions :) 

Thanks