### PR TITLE
Add work-generate

### DIFF
--- a/nanohakase/rpc.py
+++ b/nanohakase/rpc.py
@@ -50,5 +50,7 @@ class RPC:
       return self.call({"action": "receivable", "account": account, "count": str(count), "threshold": str(threshold)})
     else:
       return self.call({"action": "receivable", "account": account, "count": str(count)})
+  def work_generate(self, work_base: str):
+    return self.call({"action": "work_generate", "hash": work_base})
   #todo: delegators, delegators_count, accounts_frontiers, account_block_count
   """Action RPC calls are provided by Wallet class in wallet.py, not here"""

--- a/nanohakase/rpc.py
+++ b/nanohakase/rpc.py
@@ -50,7 +50,7 @@ class RPC:
       return self.call({"action": "receivable", "account": account, "count": str(count), "threshold": str(threshold)})
     else:
       return self.call({"action": "receivable", "account": account, "count": str(count)})
-  def work_generate(self, work_base: str):
-    return self.call({"action": "work_generate", "hash": work_base})
+  def work_generate(self, block: str):
+    return self.call({"action": "work_generate", "hash": block})
   #todo: delegators, delegators_count, accounts_frontiers, account_block_count
   """Action RPC calls are provided by Wallet class in wallet.py, not here"""

--- a/nanohakase/wallet.py
+++ b/nanohakase/wallet.py
@@ -26,7 +26,7 @@ class Wallet:
       payload["do_work"] = True
     return self.rpc.call(payload)
   #actions
-  def send(self, to: str, amount: str):
+  def send(self, to: str, amount: str, work=False):
     amount = whole_to_raw(amount)
     address_sender = self.get_address()
     private_key_sender = get_private_key_from_seed(self.seed, self.index)
@@ -50,10 +50,12 @@ class Wallet:
     block_hash = hash_block(block)
     signature = sign(private_key_sender, block_hash)
     block["signature"] = signature
-    if self.rpc.rpc_url != "https://app.natrium.io/api":
+    if work:
+      block["work"] = work
+    elif self.rpc.rpc_url != "https://app.natrium.io/api":
       block["work"] = self.rpc.work_generate(previous)["work"]
     return self.send_process(block, "send")
-  def receive_specific(self, hash: str):
+  def receive_specific(self, hash: str, work=False):
     #no need to check as opened, I think?
     #get block info of receiving
     block_info = self.rpc.get_block_info(hash)
@@ -88,7 +90,9 @@ class Wallet:
     block_hash = hash_block(block)
     signature = sign(private_key_receiver, block_hash)
     block["signature"] = signature
-    if self.rpc.rpc_url != "https://app.natrium.io/api":
+    if work:
+      block["work"] = work
+    elif self.rpc.rpc_url != "https://app.natrium.io/api":
       block["work"] = self.rpc.work_generate(previous)["work"]
     return self.send_process(block, "receive")
   def receive_all(self):
@@ -96,7 +100,7 @@ class Wallet:
     for block_hash in receivable_blocks:
       #receive them
       self.receive_specific(block_hash)
-  def change_rep(self, new_representative):
+  def change_rep(self, new_representative, work=False):
     address_self = self.get_address()
     private_key_self = get_private_key_from_seed(self.seed, self.index)
     #public_key_sender = get_public_key_from_private_key(get_private_key_from_seed(self.seed, self.index))
@@ -123,7 +127,9 @@ class Wallet:
     block_hash = hash_block(block)
     signature = sign(private_key_self, block_hash)
     block["signature"] = signature
-    if self.rpc.rpc_url != "https://app.natrium.io/api":
+    if work:
+      block["work"] = work
+    elif self.rpc.rpc_url != "https://app.natrium.io/api":
       block["work"] = self.rpc.work_generate(previous)["work"]
     return self.send_process(block, "change")
   #double wrapped

--- a/nanohakase/wallet.py
+++ b/nanohakase/wallet.py
@@ -26,7 +26,7 @@ class Wallet:
       payload["do_work"] = True
     return self.rpc.call(payload)
   #actions
-  def send(self, to: str, amount: str, work = False):
+  def send(self, to: str, amount: str):
     amount = whole_to_raw(amount)
     address_sender = self.get_address()
     private_key_sender = get_private_key_from_seed(self.seed, self.index)
@@ -50,10 +50,10 @@ class Wallet:
     block_hash = hash_block(block)
     signature = sign(private_key_sender, block_hash)
     block["signature"] = signature
-    if work:
-      block["work"] = work
+    if self.rpc.rpc_url != "https://app.natrium.io/api":
+      block["work"] = self.rpc.work_generate(previous)["work"]
     return self.send_process(block, "send")
-  def receive_specific(self, hash: str, work=False):
+  def receive_specific(self, hash: str):
     #no need to check as opened, I think?
     #get block info of receiving
     block_info = self.rpc.get_block_info(hash)
@@ -88,15 +88,15 @@ class Wallet:
     block_hash = hash_block(block)
     signature = sign(private_key_receiver, block_hash)
     block["signature"] = signature
-    if work:
-      block["work"] = work
+    if self.rpc.rpc_url != "https://app.natrium.io/api":
+      block["work"] = self.rpc.work_generate(previous)["work"]
     return self.send_process(block, "receive")
   def receive_all(self):
     receivable_blocks = self.get_receivable()["blocks"]
     for block_hash in receivable_blocks:
       #receive them
       self.receive_specific(block_hash)
-  def change_rep(self, new_representative, work=False):
+  def change_rep(self, new_representative):
     address_self = self.get_address()
     private_key_self = get_private_key_from_seed(self.seed, self.index)
     #public_key_sender = get_public_key_from_private_key(get_private_key_from_seed(self.seed, self.index))
@@ -123,8 +123,8 @@ class Wallet:
     block_hash = hash_block(block)
     signature = sign(private_key_self, block_hash)
     block["signature"] = signature
-    if work:
-      block["work"] = work
+    if self.rpc.rpc_url != "https://app.natrium.io/api":
+      block["work"] = self.rpc.work_generate(previous)["work"]
     return self.send_process(block, "change")
   #double wrapped
   def get_balance(self):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author_email="prussia@prussia.dev",
     packages=["nanohakase"],
     install_requires=["requests", "ed25519_blake2b"],
-    version="0.0.4",
+    version="0.0.5",
     license="MIT",
     description="A python library to simplify sending and receiving Nano. Also a RPC wrapper. Self fork of bananopie.",
     long_description=open("README.md").read(),


### PR DESCRIPTION
Currently this library doesn't work with most public nodes due to the lack of "do_work" support. This PR does a work_generate request before sending the block for more compatibility with public node RPCs.